### PR TITLE
(sakuli/sakuli#275) added keyword for autodiscovery to forwarder

### DIFF
--- a/packages/sakuli-forwarder-check_mk/package.json
+++ b/packages/sakuli-forwarder-check_mk/package.json
@@ -4,7 +4,8 @@
   "description": "check_mk forwarder for Sakuli v2+",
   "keywords": [
     "monitoring",
-    "e2e"
+    "e2e",
+    "sakuliPreset"
   ],
   "author": "Simon Hofmann <simon.hofmann@consol.de>",
   "main": "dist/index.js",

--- a/packages/sakuli-forwarder-gearman/package.json
+++ b/packages/sakuli-forwarder-gearman/package.json
@@ -4,7 +4,8 @@
   "description": "Gearman forwarder for Sakuli v2+",
   "keywords": [
     "monitoring",
-    "e2e"
+    "e2e",
+    "sakuliPreset"
   ],
   "author": "Simon Hofmann <simon.hofmann@consol.de>",
   "main": "dist/index.js",

--- a/packages/sakuli-forwarder-icinga2/package.json
+++ b/packages/sakuli-forwarder-icinga2/package.json
@@ -4,7 +4,8 @@
   "description": "Inciga2 forwarder for Sakuli v2+",
   "keywords": [
     "monitoring",
-    "e2e"
+    "e2e",
+    "sakuliPreset"
   ],
   "author": "Tim Keiner <keiner.tim@gmail.com>",
   "main": "dist/index.js",

--- a/packages/sakuli-forwarder-prometheus/package.json
+++ b/packages/sakuli-forwarder-prometheus/package.json
@@ -4,7 +4,8 @@
   "description": "Prometheus forwarder for Sakuli v2+",
   "keywords": [
     "monitoring",
-    "e2e"
+    "e2e",
+    "sakuliPreset"
   ],
   "author": "Sven Hettwer <sven.hettwer@consol.de>",
   "main": "dist/index.js",


### PR DESCRIPTION
Created the sakuli branch with a type so all commits are now referenced to 275 instead of 276 :man_facepalming: 