### PR TITLE
Fix/81/incorrect icinga mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Upcoming Release
+
+- Bugfix: Icinga Mapping is not correct [(#81)](https://github.com/sakuli/sakuli-enterprise-forwarder/issues/81)
+- Enhancement: change log level of "* disabled by properties" to debug [(#77)](https://github.com/sakuli/sakuli-enterprise-forwarder/issues/77)
+- Bugfix: Close gearman connection properly [(#73)](https://github.com/sakuli/sakuli-enterprise-forwarder/issues/73)
+
 ## v2.4.0
 - Enhancement: Improve logging [(#338)](https://github.com/sakuli/sakuli/issues/338)
 - Enhancement: Autodiscovery for presetprovider [(#276)](https://github.com/sakuli/sakuli/issues/276)

--- a/packages/sakuli-forwarder-icinga2/src/icinga2-forwarder.class.ts
+++ b/packages/sakuli-forwarder-icinga2/src/icinga2-forwarder.class.ts
@@ -54,7 +54,8 @@ export class Icinga2Forwarder implements Forwarder {
             const requestData: ProcessCheckResultRequest = {
                 "check_source": properties.checkSource,
                 "check_command": properties.checkCommand,
-                "exit_status": ctx.resultState,
+                //For error states we use the critical state of icinga because the error state 4 does not exist
+                "exit_status": ctx.resultState === 4 ? 2 : ctx.resultState,
                 "plugin_output": ctx.testSuites.map(createPluginOutput).reduce(flatten, []).join(EOL),
                 "performance_data": ctx.testSuites.map(createPerformanceData).reduce(flatten, []),
                 execution_start: convertToUnixTimestamp(ctx.startDate),

--- a/packages/sakuli-forwarder-icinga2/src/icinga2-forwarder.class.ts
+++ b/packages/sakuli-forwarder-icinga2/src/icinga2-forwarder.class.ts
@@ -54,7 +54,7 @@ export class Icinga2Forwarder implements Forwarder {
             const requestData: ProcessCheckResultRequest = {
                 "check_source": properties.checkSource,
                 "check_command": properties.checkCommand,
-                //For error states we use the critical state of icinga because the error state 4 does not exist
+                //For Sakuli error states we use the critical state in icinga because the error state 4 results in UNKNOWN
                 "exit_status": ctx.resultState === 4 ? 2 : ctx.resultState,
                 "plugin_output": ctx.testSuites.map(createPluginOutput).reduce(flatten, []).join(EOL),
                 "performance_data": ctx.testSuites.map(createPerformanceData).reduce(flatten, []),


### PR DESCRIPTION
After the fix, Icinga shows the critical state when the test execution fails:

![icinga-output](https://user-images.githubusercontent.com/48590838/100063840-0f9b2380-2e32-11eb-8c01-977e093f3ecd.png)
